### PR TITLE
Fix for #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [this YouTube video](https://youtu.be/dFOZCkYJdOM) for a demonstration.
 
 ## Installation
 **Chrome:**<br>
-To install from source, clone this repo and follow the instructions [here](https://developer.chrome.com/extensions/getstarted#unpacked). When prompted to select the extension directory, choose the `/dist` folder.<br>
+To install from source, download the latest [release](https://github.com/kabir-plod/spoiler-blocker/releases/latest) and follow the instructions [here](https://developer.chrome.com/extensions/getstarted#unpacked). When prompted to select the extension directory, choose the `/dist` folder.<br>
 **Firefox:**<br>
 Follow the instrutions [here](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox), choosing a file in `/dist` when prompted.
 


### PR DESCRIPTION
Link will break if repo moved to another location though, as no relative link to releases is available, and had to use the absolute link https://github.com/kabir-plod/spoiler-blocker/releases/latest