### PR TITLE
Reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prod": "webpack --config webpack.prod.config.js --progress",
     "dev": "webpack --config webpack.dev.config.js --debug --output-pathinfo --watch --progress",
-    "start": "webpack-dev-server --config webpack.devserver.config.js"
+    "start": "webpack-dev-server --config webpack.devserver.config.js",
+    "stats": "webpack --config webpack.prod.config.js --json > stats.json"
   },
   "author": "kabir-plod",
   "license": "Apache-2.0",

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,11 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Devtools from "mobx-react-devtools";
 import {observer} from "mobx-react";
 import OptionStore from "../panel/common/OptionStore";
 import optionsActions from "./optionsActions";
 import {FocusStyleManager} from "@blueprintjs/core";
 import {Switch} from "@blueprintjs/core";
+if (process.env.NODE_ENV !== "production") {
+	const Devtools = require("mobx-react-devtools");
+}
 
 FocusStyleManager.onlyShowFocusOnTabs();
 

--- a/src/panel/panel.js
+++ b/src/panel/panel.js
@@ -1,6 +1,5 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import Devtools from "mobx-react-devtools";
 import Toast from "./toast/Toast";
 import TitleBarContainer from "./title_bar/TitleBarContainer";
 import AddCardContainer from "./add_card/AddCardContainer";
@@ -8,6 +7,9 @@ import DownloadCardContainer from "./download_card/DownloadCardContainer";
 import SpoilerCardListContainer from "./spoiler_card/SpoilerCardListContainer";
 import {observer} from "mobx-react";
 import {FocusStyleManager} from "@blueprintjs/core";
+if (process.env.NODE_ENV !== "production") {
+	const Devtools = require("mobx-react-devtools");
+}
 
 FocusStyleManager.onlyShowFocusOnTabs();
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -31,7 +31,7 @@ var CopyWebpackPluginConfig = new CopyWebpackPlugin([
 	// Copy icons
 	{
 		from: path.join(__dirname, "/src/img"),
-		to: path.join(__dirname, "/dist/resources/img/")
+		to: path.join(__dirname, "/dist/img/")
 	},
 	// Copy blueprintjs stylesheet
 	{


### PR DESCRIPTION
Not much of a reduction, just removed the mobx-devtools import (~few kB) for production builds. 